### PR TITLE
Update method to calculate vaccination rate based on 7 day average.

### DIFF
--- a/src/components/time-to-herd/time-to-herd.jsx
+++ b/src/components/time-to-herd/time-to-herd.jsx
@@ -23,8 +23,8 @@ export const TimeToHerdCount = ({
   ] = useState();
   const [population, setPopulation] = useState();
   const [
-    dailyMovingAverageAsPercentPopulation,
-    setDailyMovingAverageAsPercentPopulation,
+    dailyVaccinationRateAsPercentPopulation,
+    setDailyVaccinationRateAsPercentPopulation,
   ] = useState();
   //   const [vaccinationsListByDate, setVaccinationsListByDate] = useState();
 
@@ -60,7 +60,7 @@ export const TimeToHerdCount = ({
 
       // Set values for display
       setDailyVaccinationRate(dailyRate);
-      setDailyMovingAverageAsPercentPopulation((dailyRate / population) * 100);
+      setDailyVaccinationRateAsPercentPopulation((dailyRate / population) * 100);
       setVaccineDosesDelivered(totalVaccinations);
       setPercentPopulationVaccinated(totalVaccinations / (population * 2));
     };
@@ -123,8 +123,8 @@ export const TimeToHerdCount = ({
     if (requestedData === "percentPopulationVaccinated") {
       setRequestedDataValue(percentPopulationVaccinated * 100);
     }
-    if (requestedData === "dailyMovingAverageAsPercentPopulation") {
-      setRequestedDataValue(dailyMovingAverageAsPercentPopulation);
+    if (requestedData === "dailyVaccinationRateAsPercentPopulation") {
+      setRequestedDataValue(dailyVaccinationRateAsPercentPopulation);
     }
   }, [
     setRequestedDataValue,
@@ -133,7 +133,7 @@ export const TimeToHerdCount = ({
     daysToHerd,
     dailyVaccinationRate,
     herdImmunityVaccinationThreshold,
-    dailyMovingAverageAsPercentPopulation,
+    dailyVaccinationRateAsPercentPopulation,
     percentPopulationVaccinated,
     selectedCountry,
   ]);


### PR DESCRIPTION
In the last few days, the source data has added a daily_vaccinations field,
which uses as 7 day average.  See: https://github.com/owid/covid-19-data/issues/256

This PR updates:

* The vaccination parsing to pull from the pre-calculated daily vaccination rate
* Variable names accordingly (and fixes a few minor spelling errors)
* Field selection to be dynamic based on header names, as there are indications additional data fields will be added in the future.
  * See: https://github.com/owid/covid-19-data/issues/234